### PR TITLE
Add onDidChange to theia/plugins 

### DIFF
--- a/conf/infos.yml
+++ b/conf/infos.yml
@@ -45,6 +45,24 @@ root:
     _note: '<a href="https://github.com/eclipse-theia/theia/issues/10200">#10200</a>'
   LinkedEditingRanges:
     _note: '<a href="https://github.com/eclipse-theia/theia/issues/10200">#10200</a>'
+  TestController: 
+    _note: '<a href="https://github.com/eclipse-theia/theia/issues/10669">#10669</a>'
+  TestItem: 
+    _note: '<a href="https://github.com/eclipse-theia/theia/issues/10669">#10669</a>'
+  TestItemCollection: 
+    _note: '<a href="https://github.com/eclipse-theia/theia/issues/10669">#10669</a>'
+  TestMessage: 
+    _note: '<a href="https://github.com/eclipse-theia/theia/issues/10669">#10669</a>'
+  TestRun: 
+    _note: '<a href="https://github.com/eclipse-theia/theia/issues/10669">#10669</a>'
+  TestRunProfile: 
+    _note: '<a href="https://github.com/eclipse-theia/theia/issues/10669">#10669</a>'
+  TestRunProfileKind: 
+    _note: '<a href="https://github.com/eclipse-theia/theia/issues/10669">#10669</a>'
+  TestRunRequest: 
+    _note: '<a href="https://github.com/eclipse-theia/theia/issues/10669">#10669</a>'
+  TestTag: 
+    _note: '<a href="https://github.com/eclipse-theia/theia/issues/10669">#10669</a>'
   TreeViewOptions:
     canSelectMany:
       _note: '<a href="https://github.com/eclipse-theia/theia/issues/10102">#10102</a>'
@@ -85,3 +103,8 @@ workspace:
     _note: '<a href="https://github.com/eclipse-theia/theia/issues/10472">#10472</a>'
   onDidGrantWorkspaceTrust:
     _note: '<a href="https://github.com/eclipse-theia/theia/issues/10472">#10472</a>'
+
+tests:
+  _note: '<a href="https://github.com/eclipse-theia/theia/issues/10669">#10669</a>'
+  createTestController: 
+    _note: '<a href="https://github.com/eclipse-theia/theia/issues/10669">#10669</a>'

--- a/conf/vscode-theia.d.ts
+++ b/conf/vscode-theia.d.ts
@@ -17,6 +17,8 @@ declare module '@theia/plugin' {
 
         export function getExtension<T>(extensionId: string): Extension<T> | undefined;
 
+        export let onDidChange: Event<void>;
+
         export let all: Extension<any>[];
     }
 


### PR DESCRIPTION
The naming between theia/plugins and vscode/extensions is different.
Therefore the comparator adds the vscode naming to the theia/plugins module manually.
However, the onDidChange variable was missing and therefore marked as missing in the table, while it is available in Theia.
This is fixed with this commit.

Additionally added the issue for the `tests` namespace to the corresponding rows.

Contributed on behalf of STMicroelectronics.