### PR TITLE
Added current target version

### DIFF
--- a/src/grab-vscode-versions.ts
+++ b/src/grab-vscode-versions.ts
@@ -19,6 +19,7 @@ export class GrabVSCodeVersions {
 
     static readonly VSCODE_URL_PATTERN_PRE_1_63 = 'https://raw.githubusercontent.com/Microsoft/vscode/${VERSION}/src/vs/vscode.d.ts';
     static readonly VSCODE_URL_PATTERN = 'https://raw.githubusercontent.com/Microsoft/vscode/${VERSION}/src/vscode-dts/vscode.d.ts';
+    static readonly CURRENT_REFERENCE_TARGET_VERSION = '1.55.2';
 
     private readonly content = new Content();
 
@@ -70,10 +71,16 @@ export class GrabVSCodeVersions {
                 versions.push(currVersion);
             }
         });
+
+        // keep only the last 4 versions
+        versions.length = 4;
+
+        // add main version
         versions.unshift('main');
 
-        // keep only 5 versions
-        versions.length = 5;
+        // add current reference target version
+        versions.push(GrabVSCodeVersions.CURRENT_REFERENCE_TARGET_VERSION);
+
         return versions;
     }
 

--- a/src/grab-vscode-versions.ts
+++ b/src/grab-vscode-versions.ts
@@ -19,6 +19,9 @@ export class GrabVSCodeVersions {
 
     static readonly VSCODE_URL_PATTERN_PRE_1_63 = 'https://raw.githubusercontent.com/Microsoft/vscode/${VERSION}/src/vs/vscode.d.ts';
     static readonly VSCODE_URL_PATTERN = 'https://raw.githubusercontent.com/Microsoft/vscode/${VERSION}/src/vscode-dts/vscode.d.ts';
+    // Version that is officially supported
+    static readonly CURRENT_REFERENCE_VERSION = '1.53.2';
+    // Target version that will be officially supported next
     static readonly CURRENT_REFERENCE_TARGET_VERSION = '1.55.2';
 
     private readonly content = new Content();
@@ -80,6 +83,9 @@ export class GrabVSCodeVersions {
 
         // add current reference target version
         versions.push(GrabVSCodeVersions.CURRENT_REFERENCE_TARGET_VERSION);
+
+        // add current reference version
+        versions.push(GrabVSCodeVersions.CURRENT_REFERENCE_VERSION);
 
         return versions;
     }


### PR DESCRIPTION
Add a new column to the compatibility report for a fixed VS Code version. This version is the current target reference version for compatibility, i.e. we aim to complete all missing API of this version.

fixed #17

Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>