### PR TITLE
Remove `PromiseLike` parsing

### DIFF
--- a/src/comparator.ts
+++ b/src/comparator.ts
@@ -93,13 +93,6 @@ export class Comparator {
 
     // now compare commands
 
-    updateThenable(value: string): string {
-        if (value) {
-            return value.replace(/Thenable/g, 'PromiseLike');
-        }
-        return '';
-    }
-
     compare(): void {
 
         // init map with all entries of latest vsCode
@@ -328,7 +321,7 @@ export class Comparator {
                             if (docEntryLatestVsCodeCommand.unions && docEntryLatestVsCodeCommand.unions.length > 0) {
                                 // ok so here search in all unions if it's defined in each vscode version
                                 docEntryLatestVsCodeCommand.unions.forEach(union => {
-                                    const searchedUnion = inCurrent.unions?.find(currentUnion => currentUnion.name === this.updateThenable(union.name));
+                                    const searchedUnion = inCurrent.unions?.find(currentUnion => currentUnion.name === union.name);
 
                                     // it's there, add it
                                     if (searchedUnion) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -96,8 +96,7 @@ export class Parser {
             const parameterType = this.checker.getTypeAtLocation(parameter.valueDeclaration);
             memberDoc.type = this.checker.typeToString(parameterType);
 
-            // Thenable --> PromiseLike for hash
-            toHash += memberDoc.type.replace('Thenable', 'PromiseLike');
+            toHash += memberDoc.type;
 
             details.parameters.push(memberDoc);
         });


### PR DESCRIPTION
After the discussion [#11214](https://github.com/eclipse-theia/theia/issues/11214) the `PromiseLike` Type was removed from the `theia.d.ts` file and replaced with `Thenable`. With this we should stop changing around these values in the comparator, as this could lead to site effects.
E.g. currently, the `ProviderResult#Thenable` is marked as unsupported. This is fixed with this. Furthermore, this will allow us to spot future usages of `PromiseLike`s more easily.

Follow up for #21.

Contributed on behalf of STMicroelectronics