### PR TITLE
Permit configuration of comparison via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,40 @@ The tool grabs files remotely, and checks the latest versions using the [GraphQL
     ✍️  Filtered HTML status written at /home/user/Git/vscode-theia-comparator/out/filtered-status.html
     ```
 
+## Additional CLI options
+
+### Using a local repository
+
+In order to compare the state of local repositories, you may use the `theia-path` and `vscode-path` options. If these options are provided and no additional versions are provided on the command line, only the local states will be compared.
+
+```shell
+yarn run generate theia-path=/path/to/theia vscode-path=/path/to/vscode
+```
+
+In this case, only your local Theia and VSCode repositories will be compared.
+
+```shell
+yarn run generate theia-path=/path/to/theia
+```
+
+With these arguments, your local Theia will be compared with the default set of VSCode versions fetched from GitHub.
+
+```shell
+yarn run generate theia-path=/path/to/theia theia-versions=v1.27.0
+```
+
+With this input, the local copy of Theia as well as version 1.27.0 fetched from GitHub will be compared with the default set of VSCode versions fetched from GitHub.
+
+### Defining versions for comparison
+
+In order to control the versions used for comparison, you can pass a list of comma-separated commit references (tags, branch names, SHA's) as `theia-versions` or `vscode-versions`. At present, the references must be found in the main repository (i.e. not a fork) for each comparandum.
+
+```shell
+yarn run generate theia-versions=v1.27.0,v1.26.0,master vscode-versions=main,1.0.0
+```
+
+This input will compare the `master` branch and (tagged) versions 1.27.0 and 1.26.0 of Theia with the `main` branch and (tagged) version 1.0.0 of VSCode.
+
 ## Provide additional information
 
 The generator can add notes for any namespace, element or sub element.

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
     "graphql": "^16.5.0",
     "graphql-request": "^4.3.0",
     "typescript": "^4.7.4",
+    "untildify": "^4.0.0",
     "yaml": "^2.1.1"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",
+    "@types/untildify": "^4.0.0",
     "rimraf": "^3.0.2",
     "tslint": "^6.1.3",
     "typescript-formatter": "^7.2.2"

--- a/src/abstract-version-grabber.ts
+++ b/src/abstract-version-grabber.ts
@@ -1,0 +1,61 @@
+/*********************************************************************
+* Copyright (c) 2019 Red Hat, Inc.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+
+import { ScannerEntry } from './scanner-entry';
+
+export abstract class AbstractVersionGrabber {
+    /** A prefix for CLI args for this grabber */
+    protected abstract readonly argumentPrefix: string;
+    protected abstract readonly displayName: string;
+    protected abstract readonly primaryBranchName: string;
+    protected versionsFromCLI(): string[] | undefined {
+        const argLabel = `${this.argumentPrefix}-versions=`;
+        return process.argv.slice(2).find(arg => arg.startsWith(argLabel))?.substring(argLabel.length).split(',').filter(Boolean).sort((a, b) => {
+            if (a === 'local') { return -1; }
+            if (b === 'local') { return 1; }
+            if (a === this.primaryBranchName) { return -1; }
+            if (b === this.primaryBranchName) { return 1; }
+            return 0;
+        });
+    }
+
+    async grabVersions(): Promise<string[]> {
+        return this.versionsFromCLI() ?? this.grabVersionsFromRemote();
+    }
+
+    protected abstract grabVersionsFromRemote(): Promise<string[]>;
+
+    public async grab(): Promise<ScannerEntry[]> {
+        const entryFromCli = await this.getPathFromCLI();
+        if (entryFromCli) {
+            const versionsFromCLI = this.versionsFromCLI();
+            this.logVersions([`local repository at ${entryFromCli[0].path}`].concat(versionsFromCLI ?? []));
+            return versionsFromCLI ? entryFromCli.concat(await this.versionsToEntries(versionsFromCLI)) : entryFromCli;
+        }
+        const versions = await this.grabVersions();
+        this.logVersions(versions);
+        return this.versionsToEntries(versions);
+    }
+
+    protected abstract getPathFromCLI(): Promise<[ScannerEntry] | undefined>;
+
+    protected async versionsToEntries(versions: string[]): Promise<ScannerEntry[]> {
+        process.stdout.write('🗃  Grabbing content...');
+        const entries = await Promise.all(versions.map(async version => this.versionToEntry(version)));
+        process.stdout.write('✔️ \n');
+        return entries;
+    }
+
+    protected abstract versionToEntry(version: string): Promise<ScannerEntry>;
+
+    private logVersions(versions: string[]): void {
+        console.log(`🗂  The ${this.displayName} versions to compare will be ${versions.join(', ')}`);
+    }
+}

--- a/src/comparator.ts
+++ b/src/comparator.ts
@@ -130,9 +130,7 @@ export class Comparator {
 
                 });
             }
-
-        }
-        );
+        });
 
         // ok, now compare with each version of vscode (except latest one which is first index
         // it should be only yes or N/A

--- a/src/grab-vscode-versions.ts
+++ b/src/grab-vscode-versions.ts
@@ -9,13 +9,14 @@
 **********************************************************************/
 
 import * as path from 'path';
-import * as https from 'https';
+import untildify = require('untildify');
 import { GraphQLClient } from 'graphql-request';
 import * as fs from 'fs-extra';
 import { ScannerEntry } from './scanner-entry';
 import { Content } from './content';
+import { AbstractVersionGrabber } from './abstract-version-grabber';
 
-export class GrabVSCodeVersions {
+export class GrabVSCodeVersions extends AbstractVersionGrabber {
 
     static readonly VSCODE_URL_PATTERN_PRE_1_63 = 'https://raw.githubusercontent.com/Microsoft/vscode/${VERSION}/src/vs/vscode.d.ts';
     static readonly VSCODE_URL_PATTERN = 'https://raw.githubusercontent.com/Microsoft/vscode/${VERSION}/src/vscode-dts/vscode.d.ts';
@@ -23,13 +24,15 @@ export class GrabVSCodeVersions {
     static readonly CURRENT_REFERENCE_VERSION = '1.53.2';
     // Target version that will be officially supported next
     static readonly CURRENT_REFERENCE_TARGET_VERSION = '1.55.2';
+    protected readonly argumentPrefix = 'vscode';
+    protected readonly displayName = 'VSCode';
+    protected readonly primaryBranchName = 'main';
 
     private readonly content = new Content();
 
     // grab latest 6 VSCode versions
-
-    public async grabVersions(): Promise<string[]> {
-        console.log('🔍 Searching on github the VSCode versions...');
+    protected async grabVersionsFromRemote(): Promise<string[]> {
+        console.log('🔍 Searching on GitHub for tagged VSCode versions...');
         const query = `{
     repository(owner: "Microsoft", name: "vscode") {
       refs(refPrefix: "refs/tags/", last: 20, orderBy: {field: TAG_COMMIT_DATE, direction: ASC}) {
@@ -90,26 +93,35 @@ export class GrabVSCodeVersions {
         return versions;
     }
 
-    public async grab(): Promise<ScannerEntry[]> {
-        const versions = await this.grabVersions();
-        console.log(`🗂  The VSCode versions to compare will be ${versions.join(', ')}`);
-        process.stdout.write('🗃  Grabbing content...');
+    protected async getPathFromCLI(): Promise<[ScannerEntry] | undefined> {
+        const relativePathFromCLI = untildify(process.argv.slice(2).find(arg => arg.startsWith('vscode-path='))?.substring('vscode-path='.length) ?? '');
+        if (relativePathFromCLI) {
+            if (relativePathFromCLI.endsWith('vscode.d.ts')) {
+                const absolute = path.resolve(relativePathFromCLI);
+                return (await fs.pathExists(absolute)) ? [{ version: 'local', path: absolute }] : undefined;
+            }
+            const relativeAfter163 = path.resolve(relativePathFromCLI, 'src', 'vscode-dts', 'vscode.d.ts');
+            if (await fs.pathExists(relativeAfter163)) {
+                return [{ version: 'local', path: relativeAfter163 }];
+            }
+            const relativeBefore163 = path.resolve(relativePathFromCLI, 'src', 'vs', 'vscode.d.ts');
+            if (await fs.pathExists(relativeBefore163)) {
+                return [{ version: 'local', path: relativeBefore163 }];
+            }
+        }
+    }
 
-        const versionsPath = await Promise.all(versions.map(async version => {
-            const filePath = path.resolve(__dirname, `vscode-${version}.d.ts`);
-            // The repository location of the api definition file changed with VSCode 1.63
-            const major = parseInt(version.split('.')[0]);
-            const minor = parseInt(version.split('.')[1]);
-            const urlPattern = major === 1 && minor < 63
-                ? GrabVSCodeVersions.VSCODE_URL_PATTERN_PRE_1_63
-                : GrabVSCodeVersions.VSCODE_URL_PATTERN;
-            const url = urlPattern.replace('${VERSION}', version);
-            const content = await this.content.get(url);
-            await fs.writeFile(filePath, content);
-            const entry: ScannerEntry = { path: filePath, version };
-            return entry;
-        }));
-        process.stdout.write('✔️ \n');
-        return versionsPath;
+    protected async versionToEntry(version: string): Promise<ScannerEntry> {
+        const filePath = path.resolve(__dirname, `vscode-${version}.d.ts`);
+        // The repository location of the api definition file changed with VSCode 1.63
+        const major = parseInt(version.split('.')[0]);
+        const minor = parseInt(version.split('.')[1]);
+        const urlPattern = major === 1 && minor < 63
+            ? GrabVSCodeVersions.VSCODE_URL_PATTERN_PRE_1_63
+            : GrabVSCodeVersions.VSCODE_URL_PATTERN;
+        const url = urlPattern.replace('${VERSION}', version);
+        const content = await this.content.get(url);
+        await fs.writeFile(filePath, content);
+        return { path: filePath, version };
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,13 +19,9 @@ import { parseInfos } from './infos';
 
 async function init() {
 
-    // grab remote VS Code versions dumped locally
-    const grabTheiaVersions = new GrabTheiaVersions();
-    const theiaEntries = await grabTheiaVersions.grab();
-
-    // grab remote VS Code versions dumped locally
-    const grabVSCodeVersions = new GrabVSCodeVersions();
-    const vsCodeEntries = await grabVSCodeVersions.grab();
+    // Find or download the declaration files for Theia and VSCode
+    const theiaEntries = await new GrabTheiaVersions().grab();
+    const vsCodeEntries = await new GrabVSCodeVersions().grab();
 
     // start comparator
     const comparator = new Comparator(vsCodeEntries, theiaEntries);
@@ -62,7 +58,7 @@ if (!process.env.GITHUB_TOKEN) {
 } else {
 
     init().catch(err => {
-        console.error(`🚒 ${err}`);
+        console.error(`🚒 ${err.stack}`);
         process.exit(1);
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,6 +28,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.44.tgz#447e3eecad9d19bd779f4a575f361d34898c0722"
   integrity sha512-gwP6+QDgL5TDBIWh1lbYh3EFPU11pa+8xcamcsA3ROkp3A9X+/3Y5cRgq93VPEEE+CGfxlQnqkg1kkWGBgh3fw==
 
+"@types/untildify@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/untildify/-/untildify-4.0.0.tgz#48f51e62b38baf7244fa527eacd3d9f605540e14"
+  integrity sha512-AoSIFVSN4k0l6yD2QKw2TWQkhH3sKsDpke2ozD69WfjPiDmoNJjah+oPUfiJTdCZZqC7pdEq8c5p8vdm5hvn9Q==
+  dependencies:
+    untildify "*"
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -440,6 +447,11 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
+
+untildify@*, untildify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
+  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
This PR introduces the ability to run comparisons on local repositories for both Theia and VSCode (fully offline comparison) and to customize the versions of each declaration file used for comparison. The aim is to make it easier to detect regressions between versions or between the current state on `master` and a working or local branch. If no CLI arguments are provided, the behavior remains the same as before.

Added to the README:

## Additional CLI options

### Using a local repository

In order to compare the state of local repositories, you may use the `theia-path` and `vscode-path` options. If these options are provided and no additional versions are provided on the command line, only the local states will be compared.

```shell
yarn run generate theia-path=/path/to/theia vscode-path=/path/to/vscode
```

In this case, only your local Theia and VSCode repositories will be compared.

```shell
yarn run generate theia-path=/path/to/theia
```

With these arguments, your local Theia will be compared with the default set of VSCode versions fetched from GitHub.

```shell
yarn run generate theia-path=/path/to/theia theia-versions=v1.27.0
```

With this input, the local copy of Theia as well as version 1.27.0 fetched from GitHub will be compared with the default set of VSCode versions fetched from GitHub.

### Defining versions for comparison

In order to control the versions used for comparison, you can pass a list of comma-separated commit references (tags, branch names, SHA's) as `theia-versions` or `vscode-versions`. At present, the references must be found in the main repository (i.e. not a fork) for each comparandum.

```shell
yarn run generate theia-versions=v1.27.0,v1.26.0,master vscode-versions=main,1.0.0
```

This input will compare the `master` branch and (tagged) versions 1.27.0 and 1.26.0 of Theia with the `main` branch and (tagged) version 1.0.0 of VSCode.