### PR TITLE
Handle @stubbed markings from theia API versions

### DIFF
--- a/src/comparator.ts
+++ b/src/comparator.ts
@@ -11,6 +11,7 @@
 import { ScannerEntry } from './scanner-entry';
 import { Parser } from './parser';
 import { DocEntry } from './doc-entry';
+import { Available } from './included';
 
 export class Comparator {
 
@@ -91,6 +92,10 @@ export class Comparator {
         return oneWay.length === otherWay.length && oneWay.length === constructor1.parameters.length;
     }
 
+    resolveYesOrStubbed(stubbed: boolean) {
+        return stubbed ? Available.Stubbed : Available.Yes;
+    }
+
     // now compare commands
 
     compare(): void {
@@ -105,26 +110,26 @@ export class Comparator {
             if (vscodeCommands) {
                 vscodeCommands.forEach(command => {
                     command.includedIn = [];
-                    command.includedIn.push({ version: `vscode/${latestVersion}`, available: 'defined' });
+                    command.includedIn.push({ version: `vscode/${latestVersion}`, available: Available.Defined });
 
                     if (command.members) {
                         command.members.forEach(member => {
                             member.includedIn = [];
-                            member.includedIn.push({ version: `vscode/${latestVersion}`, available: 'defined' });
+                            member.includedIn.push({ version: `vscode/${latestVersion}`, available: Available.Defined });
                         });
                     }
 
                     if (command.constructors) {
                         command.constructors.forEach(constructor => {
                             constructor.includedIn = [];
-                            constructor.includedIn.push({ version: `vscode/${latestVersion}`, available: 'defined' });
+                            constructor.includedIn.push({ version: `vscode/${latestVersion}`, available: Available.Defined });
                         });
                     }
 
                     if (command.unions) {
                         command.unions.forEach(union => {
                             union.includedIn = [];
-                            union.includedIn.push({ version: `vscode/${latestVersion}`, available: 'defined' });
+                            union.includedIn.push({ version: `vscode/${latestVersion}`, available: Available.Defined });
                         });
                     }
 
@@ -162,17 +167,17 @@ export class Comparator {
                         }
                         if (!inCurrent) {
                             // need to flag it as 'N/A'
-                            docEntryLatestVsCodeCommand.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: 'N/A' });
+                            docEntryLatestVsCodeCommand.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: Available.NA });
 
                             // Flag all members as N/A
                             if (docEntryLatestVsCodeCommand.members && docEntryLatestVsCodeCommand.members.length > 0) {
                                 docEntryLatestVsCodeCommand.members.forEach(member => {
-                                    member.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: 'N/A' });
+                                    member.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: Available.NA });
                                 });
                             }
                         } else {
                             // it's there, add it
-                            docEntryLatestVsCodeCommand.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: 'defined' });
+                            docEntryLatestVsCodeCommand.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: Available.Defined });
 
                             // now check members
                             if (docEntryLatestVsCodeCommand.members && docEntryLatestVsCodeCommand.members.length > 0) {
@@ -183,9 +188,9 @@ export class Comparator {
 
                                     // it's there, add it
                                     if (searchedMember) {
-                                        member.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: 'defined' });
+                                        member.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: Available.Defined });
                                     } else {
-                                        member.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: 'N/A' });
+                                        member.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: Available.NA });
                                     }
 
                                 });
@@ -200,9 +205,9 @@ export class Comparator {
 
                                     // it's there, add it
                                     if (searchedConstructor) {
-                                        constructor.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: 'defined' });
+                                        constructor.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: Available.Defined });
                                     } else {
-                                        constructor.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: 'N/A' });
+                                        constructor.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: Available.NA });
                                     }
 
                                 });
@@ -217,9 +222,9 @@ export class Comparator {
 
                                     // it's there, add it
                                     if (searchedUnion) {
-                                        union.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: 'defined' });
+                                        union.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: Available.Defined });
                                     } else {
-                                        union.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: 'N/A' });
+                                        union.includedIn.push({ version: `vscode/${this.vsCodeEntries[i].version}`, available: Available.NA });
                                     }
 
                                 });
@@ -264,23 +269,23 @@ export class Comparator {
                         }
                         if (!inCurrent) {
                             // need to flag it as 'no'
-                            docEntryLatestVsCodeCommand.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: 'no' });
+                            docEntryLatestVsCodeCommand.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: Available.No });
 
                             // Flag all members as N/A
                             if (docEntryLatestVsCodeCommand.members && docEntryLatestVsCodeCommand.members.length > 0) {
                                 docEntryLatestVsCodeCommand.members.forEach(member => {
-                                    member.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: 'no' });
+                                    member.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: Available.No });
                                 });
                             }
 
                             if (docEntryLatestVsCodeCommand.constructors && docEntryLatestVsCodeCommand.constructors.length > 0) {
                                 docEntryLatestVsCodeCommand.constructors.forEach(constructor => {
-                                    constructor.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: 'no' });
+                                    constructor.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: Available.No });
                                 });
                             }
                         } else {
                             // it's there, add it
-                            docEntryLatestVsCodeCommand.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: 'yes' });
+                            docEntryLatestVsCodeCommand.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: this.resolveYesOrStubbed(inCurrent.stubbed) });
 
                             // now check members
                             if (docEntryLatestVsCodeCommand.members && docEntryLatestVsCodeCommand.members.length > 0) {
@@ -291,9 +296,9 @@ export class Comparator {
 
                                     // it's there, add it
                                     if (searchedMember) {
-                                        member.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: 'yes' });
+                                        member.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: this.resolveYesOrStubbed(searchedMember.stubbed) });
                                     } else {
-                                        member.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: 'no' });
+                                        member.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: Available.No });
                                     }
 
                                 });
@@ -307,9 +312,9 @@ export class Comparator {
 
                                     // it's there, add it
                                     if (searchedConstructor) {
-                                        constructor.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: 'yes' });
+                                        constructor.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: this.resolveYesOrStubbed(searchedConstructor.stubbed) });
                                     } else {
-                                        constructor.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: 'no' });
+                                        constructor.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: Available.No });
                                     }
 
                                 });
@@ -323,9 +328,9 @@ export class Comparator {
 
                                     // it's there, add it
                                     if (searchedUnion) {
-                                        union.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: 'yes' });
+                                        union.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: this.resolveYesOrStubbed(searchedUnion.stubbed) });
                                     } else {
-                                        union.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: 'no' });
+                                        union.includedIn.unshift({ version: `theia/${theiaEntry.version}`, available: Available.No });
                                     }
 
                                 });
@@ -396,7 +401,7 @@ export class Comparator {
         return entry.includedIn && entry.includedIn.reduce((result, included) => {
             // Only look at theia versions.
             if (included.version.startsWith('theia/')) {
-                return result && included.available === 'yes';
+                return result && included.available === Available.Yes;
             }
             return result;
         }, true);

--- a/src/doc-entry.ts
+++ b/src/doc-entry.ts
@@ -15,6 +15,7 @@ export interface DocEntry {
     type?: string,
     optional?: boolean,
     documentation?: string,
+    stubbed?: boolean,
     kind?: string,
     signatures?: DocEntry[],
     parameters?: DocEntry[],

--- a/src/included.ts
+++ b/src/included.ts
@@ -8,7 +8,15 @@
 * SPDX-License-Identifier: EPL-2.0
 **********************************************************************/
 
+export enum Available {
+    Yes = 'yes',
+    Defined = 'defined',
+    No = 'no',
+    NA = 'N/A',
+    Stubbed = 'stubbed'
+}
+
 export interface Included {
     version: string;
-    available: 'yes' | 'defined' | 'no' | 'N/A';
+    available: Available;
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -10,6 +10,7 @@
 
 import * as ts from 'typescript';
 import { DocEntry } from './doc-entry';
+import { Available } from './included';
 
 export class Parser {
 
@@ -22,6 +23,7 @@ export class Parser {
     ({
         name: symbol.getName(),
         documentation: ts.displayPartsToString(symbol.getDocumentationComment(this.checker)),
+        stubbed: this.hasStubbedTag(symbol.getJsDocTags(this.checker)),
         type: this.checker.typeToString(
             this.checker.getTypeOfSymbolAtLocation(symbol, symbol.valueDeclaration!)
         ),
@@ -34,6 +36,7 @@ export class Parser {
         const details = {
             name: symbol.getName(),
             documentation: ts.displayPartsToString(symbol.getDocumentationComment(this.checker)),
+            stubbed: this.hasStubbedTag(symbol.getJsDocTags(this.checker)),
             type: this.checker.typeToString(enumType),
             handleType: 'EnumDeclaration',
             members: []
@@ -44,7 +47,9 @@ export class Parser {
                 let typeDoc: DocEntry = {};
                 typeDoc = {
                     name: type.symbol.getEscapedName(),
-                    value: '' + (type as ts.LiteralType).value
+                    value: '' + (type as ts.LiteralType).value,
+                    documentation: ts.displayPartsToString(type.symbol.getDocumentationComment(this.checker)),
+                    stubbed: this.hasStubbedTag(type.symbol.getJsDocTags(this.checker))
                 };
                 details.members.push(typeDoc);
 
@@ -68,6 +73,10 @@ export class Parser {
             (((prevHash << 5) - prevHash) + currVal.charCodeAt(0)) | 0, 0);
     }
 
+    private hasStubbedTag(tags: { name: string }[]): boolean {
+        return !!tags.find((tag) => tag.name === Available.Stubbed);
+    }
+
     private serializeFunction(node: ts.Node, symbol: ts.Symbol) {
 
         const funcType = this.checker.getTypeAtLocation(node);
@@ -79,6 +88,7 @@ export class Parser {
         const details: DocEntry = {
             name: symbol.getName(),
             documentation: ts.displayPartsToString(symbol.getDocumentationComment(this.checker)),
+            stubbed: this.hasStubbedTag(symbol.getJsDocTags(this.checker)),
             return: returnType,
             handleType: 'FunctionDeclaration',
             parameters: []
@@ -112,6 +122,7 @@ export class Parser {
         const details = {
             name: symbol.getName(),
             documentation: ts.displayPartsToString(symbol.getDocumentationComment(this.checker)),
+            stubbed: this.hasStubbedTag(symbol.getJsDocTags(this.checker)),
             type: this.checker.typeToString(interfaceType),
             handleType: 'InterfaceDeclaration',
             members: []
@@ -134,6 +145,7 @@ export class Parser {
             } catch (error) {
                 memberDoc.documentation = '';
             }
+            memberDoc.stubbed = this.hasStubbedTag(member.getJsDocTags(this.checker));
             memberDoc.return = this.checker.typeToString(this.checker.getTypeAtLocation(member.declarations[0]));
             details.members.push(memberDoc);
         });
@@ -147,6 +159,7 @@ export class Parser {
         const details = {
             name: symbol.getName(),
             documentation: ts.displayPartsToString(symbol.getDocumentationComment(this.checker)),
+            stubbed: this.hasStubbedTag(symbol.getJsDocTags(this.checker)),
             type: this.checker.typeToString(interfaceType),
             handleType: 'TypeAliasDeclaration',
             unions: []
@@ -224,7 +237,8 @@ export class Parser {
         if (memberDeclarations.length > 0) {
             const memberDoc: DocEntry = {};
             memberDoc.documentation = ts.displayPartsToString(symbol.getDocumentationComment(this.checker));
-            memberDoc.name = symbol.name;
+            memberDoc.stubbed = this.hasStubbedTag(symbol.getJsDocTags(this.checker)),
+                memberDoc.name = symbol.name;
 
             const callSignature = this.getCallSignature(symbol);
             if (callSignature) {
@@ -286,6 +300,7 @@ export class Parser {
         return {
             name: symbol.getName(),
             documentation: ts.displayPartsToString(symbol.getDocumentationComment(this.checker)),
+            stubbed: this.hasStubbedTag(symbol.getJsDocTags(this.checker)),
             type: this.checker.typeToString(
                 this.checker.getTypeOfSymbolAtLocation(symbol, symbol.valueDeclaration!)
             ),
@@ -301,6 +316,7 @@ export class Parser {
         const details = {
             name: symbol.getName(),
             documentation: ts.displayPartsToString(symbol.getDocumentationComment(this.checker)),
+            stubbed: this.hasStubbedTag(symbol.getJsDocTags(this.checker)),
             type: this.checker.typeToString(variableType),
             handleType: 'VariableDeclaration'
         };


### PR DESCRIPTION
Fixes: https://github.com/eclipse-theia/vscode-theia-comparator/issues/34

This change handles `@stubbed`  markings  from `theia.d.ts` versions,
the markings are expected within the boundaries of corresponding 'jsdoc` 

This change updates the parser in order to read the special `@stubbed` marking and
make this information available to the sequence generating the `html` reports.

How to Test:
Replace `grab-theia-versions.ts#THEIA_URL_PATTERN`,
  to:  'https://raw.githubusercontent.com/alvsan09/test_theia.d.ts/${VERSION}/theia.d.ts'

The above URL points to a repository containing modified `theia.d.ts` files which are git tagged with versions i.e. 
v1.28.0, v1.29.0 and the latest master, the markings are in different places covering Classes, Interfaces, Enums, functions, etc..

- Build the project and generate the reports
- A copy of the resulting `filtered-status.html` is found at: https://gist.github.com/alvsan09/a329e2a1c91992577d1618e562688f41
- The API marked as stubbed shall be reflected with an orange background and the text `stubbed`

NOTE: During the testing, it was noted that constructors require a special parsing, so `jsdoc`'s are not directly read and therefore markings as well as documentation hover on constructors are currently not supported.

Related to: #36 

Example view: 
![filtered_status_stubbed](https://user-images.githubusercontent.com/76971376/186995420-88f28430-18b2-4be7-86e5-b3ffa9ebf701.png)

