### PR TITLE
Check node for stubbed, not declarations

### DIFF
--- a/src/html-generator/html-generator.ts
+++ b/src/html-generator/html-generator.ts
@@ -123,7 +123,7 @@ const updateSuccessValue = (successes: Array<SupportLevels>, index: number, newV
     if (current === SupportLevels.Partial || current === newValue) { return; }
     if (current === undefined) {
         successes[index] = newValue;
-    } else if (current === SupportLevels.Full) {
+    } else if (current === SupportLevels.Full || newValue === SupportLevels.Full) {
         successes[index] = SupportLevels.Partial;
     } else {
         successes[index] = Math.max(current, newValue);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -132,7 +132,8 @@ export class Parser {
             Object.entries(vscodeSide).forEach(([key, target]) => {
                 const correspondent: TypeContainer | NodeAndType | undefined = theiaSide[key];
                 if (isType(target) && isType(correspondent)) {
-                    const isStubbed = (correspondent.type.symbol?.declarations ?? []).flatMap(node => ts.getJSDocTags(node)).some(tag => tag.tagName.escapedText === 'stubbed');
+                    const isStubbed = ts.getJSDocTags(correspondent.node)
+                        .some(tag => tag.tagName.escapedText === 'stubbed');
                     if (isStubbed) {
                         result[key] = SupportLevels.Stubbed;
                         failures[key] = SupportLevels.Stubbed;


### PR DESCRIPTION
Fixes #39 

The old code looked up declarations for the types used in a given class or interface and then reported whether those types were stubbed. That was incorrect. This code checks the node itself to see whether it is marked as `@stubbed`.