### PR TITLE
comparator: update default api

### DIFF
--- a/src/grab-vscode-versions.ts
+++ b/src/grab-vscode-versions.ts
@@ -21,9 +21,9 @@ export class GrabVSCodeVersions extends AbstractVersionGrabber {
     static readonly VSCODE_URL_PATTERN_PRE_1_63 = 'https://raw.githubusercontent.com/Microsoft/vscode/${VERSION}/src/vs/vscode.d.ts';
     static readonly VSCODE_URL_PATTERN = 'https://raw.githubusercontent.com/Microsoft/vscode/${VERSION}/src/vscode-dts/vscode.d.ts';
     // Version that is officially supported
-    static readonly CURRENT_REFERENCE_VERSION = '1.53.2';
+    static readonly CURRENT_REFERENCE_VERSION = '1.55.2';
     // Target version that will be officially supported next
-    static readonly CURRENT_REFERENCE_TARGET_VERSION = '1.55.2';
+    static readonly CURRENT_REFERENCE_TARGET_VERSION = '1.64.2';
     protected readonly argumentPrefix = 'vscode';
     protected readonly displayName = 'VSCode';
     protected readonly primaryBranchName = 'main';


### PR DESCRIPTION
**Description**

The supported vscode api version was updated in the framework from `1.53.2` to `1.55.2` (https://github.com/eclipse-theia/theia/pull/11823).
The changes updated the comparator to reflect the new default and target version.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>