### PR TITLE
padding:left -> padding-left

### DIFF
--- a/src/html-generator/style.ts
+++ b/src/html-generator/style.ts
@@ -61,7 +61,7 @@ th.left.depth-2 {
 }
 
 th.left.depth-3 {
-	padding:left: 2.8rem;
+	padding-left: 2.8rem;
 	font-weight: normal;
 }
 


### PR DESCRIPTION
There is a minor typo in the style specifications for the generated HTML. This MR changes the mistaken `padding:left` to the correct `padding-left`.