### PR TITLE
ci: add `workflow_dispatch`

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,5 +1,6 @@
 name: Generate and publish report
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
**Description**

The pull-request adds a `workflow_dispatch` to allow contributors the ability to manually trigger CI to generate and publish the compatibility report without the need to wait for the daily cron.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>