### PR TITLE
chore: replace 3rd party action with native GH Pages deployment

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -12,11 +12,12 @@ on:
     - cron: "0 3 * * *"
 
 permissions:
-  contents: write
+  pages: write
+  id-token: write
 
 jobs:
-  report:
-    name: Generate Report
+  build:
+    name: Build Report
     runs-on: ubuntu-22.04
     timeout-minutes: 15
 
@@ -40,11 +41,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy to Github pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: ./out
-          user_name: "github-actions[bot]"
-          user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+          path: ./out
+
+  deploy:
+    name: Deploy Report to GitHub Pages
+    runs-on: ubuntu-22.04
+    needs: build
+    environment: github-pages
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
- Use actions/upload-pages-artifact + actions/deploy-pages instead of third-party action
- Split into separate build and deploy jobs
- Reduce permissions from contents:write to pages:write
- Repo setting gh_pages_build_type was changed from "legacy" to "workflow"

Contributed on behalf of STMicroelectronics

Depends on: https://github.com/eclipse-theia/.eclipsefdn/pull/17